### PR TITLE
Allow working without rrlogd

### DIFF
--- a/src/oucher.go
+++ b/src/oucher.go
@@ -267,6 +267,7 @@ func processLine(line string, phrases []phrase, config *configuration) {
 	// If there is already an ouch in progress, do nothing
 	if IsOuching {
 		log.Debug("Already ouching, doing nothing")
+		ouchingMutex.Unlock()
 		return
 	}
 
@@ -301,7 +302,9 @@ func ouch(phrases []phrase, config *configuration) {
 	}
 
 	// Unset the ouching semaphore
+	ouchingMutex.Lock()
 	IsOuching = false
+	ouchingMutex.Unlock()
 }
 
 // Invoke the espeak command, piping it with aplay


### PR DESCRIPTION
This addresses the case when a Gen2 with 1910 firmware runs with rrlogd disabled. The old behavior of watching multiple files in both the nav_normal and player_fprintf format is restored, and a third file (/run/shm/NAV_TRAP_normal.log) is added to the watches by default.